### PR TITLE
improve and fix typos in debian container image

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -6,13 +6,13 @@ WORKDIR /go/src/crowdsec
 
 # wizard.sh requires GNU coreutils
 RUN apt-get update && apt-get install -y git jq gcc libc-dev make bash gettext binutils-gold coreutils tzdata python3 python3-pip
-RUN pip3 install yq
 
 COPY . .
 
 RUN SYSTEM="docker" make release
 RUN cd crowdsec-v* && ./wizard.sh --docker-mode && cd -
 RUN cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v4
 
 FROM debian:bullseye-slim
 
@@ -24,16 +24,17 @@ RUN apt-get install -y -q --install-recommends --no-install-suggests \
     ca-certificates \
     bash \
     tzdata && \
-  mkdir -p /staging/etc/crowdsec && \
-  mkdir -p /staging/var/lib/crowdsec
+    mkdir -p /staging/etc/crowdsec && \
+    mkdir -p /staging/var/lib/crowdsec
 
-COPY --from=build /usr/local/bin/yq /usr/local/bin/yq
+COPY --from=build /go/bin/yq /usr/local/bin/yq
 COPY --from=build /etc/crowdsec /staging/etc/crowdsec
 COPY --from=build /var/lib/crowdsec /staging/var/lib/crowdsec
 COPY --from=build /usr/local/bin/crowdsec /usr/local/bin/crowdsec
 COPY --from=build /usr/local/bin/cscli /usr/local/bin/cscli
 COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
-COPY --from=build /go/src/crowdsec/config/config.yaml /staging/etc/crowdsec/config.yaml
+COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
+RUN yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 #Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
 #The files are here for reference, as users will need to mount a new version to be actually able to use notifications
 COPY --from=build /go/src/crowdsec/plugins/notifications/http/http.yaml /staging/etc/crowdsec/notifications/http.yaml

--- a/docker/README.md
+++ b/docker/README.md
@@ -127,7 +127,10 @@ Using binds rather than named volumes ([more explanation here](https://docs.dock
 * `CERT_FILE`               - TLS Certificate file (default: `/etc/ssl/cert.pem`) : `-e CERT_FILE="<file_path>"`
 * `KEY_FILE`                - TLS Key file (default: `/etc/ssl/key.pem`) : `-e KEY_FILE="<file_path>"`
 * `CUSTOM_HOSTNAME`         - Custom hostname for local api (default: `localhost`) : `-e CUSTOM_HOSTNAME="<hostname>"`
-* `DISABLE_SCENARIOS`       - Scenarios to uninstall from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_SCENARIOS="crowdsecurity/http-bad-user-agent crowdsecurity/http-xss-probing"`
+* `DISABLE_COLLECTIONS`       - Collections to remove from the [hub](https://hub.crowdsec.net/browse/#collections), separated by space : `-e DISABLE_COLLECTIONS="crowdsecurity/linux crowdsecurity/nginx"`
+* `DISABLE_PARSERS`         - Parsers to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_PARSERS="crowdsecurity/apache2-logs crowdsecurity/nginx-logs"`
+* `DISABLE_SCENARIOS`       - Scenarios to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_SCENARIOS="crowdsecurity/http-bad-user-agent crowdsecurity/http-xss-probing"`
+* `DISABLE_POSTOVERFLOWS`   - Postoverflows to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_POSTOVERFLOWS="crowdsecurity/cdn-whitelist crowdsecurity/seo-bots-whitelist"`
 * `PLUGIN_DIR`              - Directory for plugins (default: `/usr/local/lib/crowdsec/plugins/`) : `-e PLUGIN_DIR="<path>"`
 
 ## Volumes

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -44,7 +44,7 @@ if [ "$DISABLE_AGENT" == "" ] ; then
 fi
 
 # Check if lapi needs to automatically register an agent
-echo Check if lapi need to register automatically an agent
+echo "Check if lapi need to register automatically an agent"
 if [ "$DISABLE_LOCAL_API" == "" ] && [ "$AGENT_USERNAME" != "" ] && [ "$AGENT_PASSWORD" != "" ] ; then
     cscli -c "$CS_CONFIG_FILE" machines add $AGENT_USERNAME --password $AGENT_PASSWORD
     echo "Agent registered to lapi"
@@ -77,11 +77,11 @@ if [ "$USE_TLS" != "" ]; then
    yq -i eval '... comments=""' "$CS_CONFIG_FILE"
 fi
 
-if [ "$PLUGIN_DIR" != "" ]; then
+if [ "$PLUGIN_DIR" != "/usr/local/lib/crowdsec/plugins/" ]; then
    yq -i eval ".config_paths.plugin_dir = \"$PLUGIN_DIR\"" "$CS_CONFIG_FILE"
 fi
 
-## Install collections, parsers & scenarios
+## Install collections, parsers, scenarios & postoverflows
 cscli -c "$CS_CONFIG_FILE" hub update
 cscli -c "$CS_CONFIG_FILE" collections upgrade crowdsecurity/linux || true
 cscli -c "$CS_CONFIG_FILE" parsers upgrade crowdsecurity/whitelists || true
@@ -98,8 +98,19 @@ fi
 if [ "$POSTOVERFLOWS" != "" ]; then
     cscli -c "$CS_CONFIG_FILE" postoverflows install $POSTOVERFLOWS
 fi
+
+## Remove collections, parsers, scenarios & postoverflows
+if [ "$DISABLE_COLLECTIONS" != "" ]; then
+    cscli -c "$CS_CONFIG_FILE" collections remove $DISABLE_COLLECTIONS
+fi
+if [ "$DISABLE_PARSERS" != "" ]; then
+    cscli -c "$CS_CONFIG_FILE" parsers remove $DISABLE_PARSERS
+fi
 if [ "$DISABLE_SCENARIOS" != "" ]; then
-    cscli -c "$CS_CONFIG_FILE" scenarios uninstall $DISABLE_SCENARIOS
+    cscli -c "$CS_CONFIG_FILE" scenarios remove $DISABLE_SCENARIOS
+fi
+if [ "$DISABLE_POSTOVERFLOWS" != "" ]; then
+    cscli -c "$CS_CONFIG_FILE" postoverflows remove $DISABLE_POSTOVERFLOWS
 fi
 
 ARGS=""


### PR DESCRIPTION
* because of different soft between yq from pypi ad yq from alpine (the golang version), We need to use same yq binary.
* Reuse docker/config.yaml but change the `nobody` to `nogroup` for debian and keep same config for container (stdout logging etc...)
* Fix typos
* Add `DISABLE_(COLLECTIONS|PARSERS|SCENARIOS|POSTOVERFLOWS)`